### PR TITLE
Add missing requirements to run train_net.py tool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,6 @@ scikit-learn>=1.0.2
 torch==1.10.1
 torchvision==0.11.2
 tqdm>=4.41.0
+tensorboard==2.9.0
+setuptools==59.5.0
+pytorch-ignite==0.4.9


### PR DESCRIPTION
Hey :)

I tried running train_net.py and wanted to train the segmentation network. Unfortunately, when following your instructions I still got missing imports. Using this requirements.txt it seems to start training for me (still crashes due to CUDA out of memory). 

My set-up:
- WSL2 with Ubuntu 20.04 LTS
- Miniconda 4.12.0

On a sidenote (I can create a dedicated issue if that's desired): Are the weights for the segmentation model publicly available? I would appreciate being able to iterate based upon that, without training a new network.

Best regards,
Robert :)